### PR TITLE
chore(ci): fix striping of v in docker tags

### DIFF
--- a/docker-build-push/action.yaml
+++ b/docker-build-push/action.yaml
@@ -62,7 +62,7 @@ runs:
         images: tykio/${{ inputs.repository_name }}
         tags: |
           type=sha
-          type=semver,pattern=v{{version}},value=${{ inputs.tags }}
+          type=semver,pattern={{raw}},value=${{ inputs.tags }}
 
     - uses: docker/build-push-action@v4
       with:


### PR DESCRIPTION
Change fixes removing of `v` in docker image tags. 
With current set up we are pushing `1.0.0` tag instead of `v1.0.0`.