### PR TITLE
Fix docker cache cache step

### DIFF
--- a/docker-build-push/action.yaml
+++ b/docker-build-push/action.yaml
@@ -43,12 +43,12 @@ runs:
   steps:
     - uses: docker/setup-qemu-action@v2
 
-    - uses: docker/setup-buildx-action@v2
+    - uses: docker/setup-buildx-action@v3
       with:
         driver-opts: image=moby/buildkit:master
         install: true
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache-${{ inputs.repository_name }}
         key: ${{ runner.os }}-buildx-${{ inputs.repository_name }}-${{ github.sha }}
@@ -64,7 +64,7 @@ runs:
           type=sha
           type=semver,pattern={{raw}},value=${{ inputs.tags }}
 
-    - uses: docker/build-push-action@v4
+    - uses: docker/build-push-action@v6
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
@@ -74,3 +74,8 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=local,src=/tmp/.buildx-cache-${{ inputs.repository_name }}
         cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-${{ inputs.repository_name }}-new
+
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache-${{ inputs.repository_name }}
+        mv /tmp/.buildx-cache-${{ inputs.repository_name }}-new /tmp/.buildx-cache-${{ inputs.repository_name }}         


### PR DESCRIPTION
Based on the docs, the current workflow is missing the part where the cache is moved to take the cache layers from the right place and avoid cache local storage to be filled up quickly[Cache management](https://docs.docker.com/build/ci/github-actions/cache/)