### PR TITLE
Add feature for non-semver tags

### DIFF
--- a/docker-build-push/action.yaml
+++ b/docker-build-push/action.yaml
@@ -63,6 +63,7 @@ runs:
         tags: |
           type=sha
           type=semver,pattern={{raw}},value=${{ inputs.tags }}
+          type=raw,value=${{ inputs.tags }}
 
     - uses: docker/build-push-action@v6
       with:


### PR DESCRIPTION
I need a way to release docker images with custom tags for the **webhooks-vX.x.x** image that lives in the **sre-autopilot** monorepo https://github.com/TykTechnologies/sre-autopilot/tree/main/webhooks