### PR TITLE
Fix/terraform format 0.12.31

### DIFF
--- a/terraform-format/action.yml
+++ b/terraform-format/action.yml
@@ -19,34 +19,80 @@ runs:
         MAJOR="$(echo "${TFVERSION}" | cut -d. -f1)"
         MINOR="$(echo "${TFVERSION}" | cut -d. -f2)"
 
-        # If major=0 and minor<13 => Terraform is < 0.13
+        # Decide what to put into the Helm provider block
+        HELM_PROVIDER_VERSION=""
         if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 13 ]; then
-          cat <<EOF > provider.ci.tf
-            provider "aws" {
-              region = "eu-central-1"
-            }
-
-            provider "kubernetes" {}
-
-            # Pin Helm provider for Terraform < 0.13
-            provider "helm" {
-              version = "~> 0.10"
-            }
-            EOF
-        else
-          # For Terraform >= 0.13, no explicit pin needed
-          cat <<EOF > provider.ci.tf
-            provider "aws" {
-              region = "eu-central-1"
-            }
-
-            provider "kubernetes" {}
-
-            provider "helm" {}
-            EOF
+          HELM_PROVIDER_VERSION='  version = "~> 0.10"'
         fi
 
-        # Format the newly created file
+        # Write one provider file, inserting our dynamic Helm version
+        cat <<EOF > provider.ci.tf
+provider "aws" {
+  region = "eu-central-1"
+}
+
+provider "kubernetes" {}
+
+provider "helm" {
+${HELM_PROVIDER_VERSION}
+}
+EOF
+
+        # Format the file
+        terraform fmt -write=true provider.ci.tf
+
+    - name: Terraform init
+      shell: bash
+      run: terraform init
+
+    - name: Terraform validate
+      shell: bash
+      run: terraform validate
+
+    - name: Terraform fmt
+      shell: bash
+      run: terraform fmt -check -recursive -diff .
+---
+name: Terraform Formatter
+description: Runs terraform validate and format
+
+inputs:
+  terraform_version:
+    description: 'Terraform version'
+    required: true
+    default: '0.12.31'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Write provider file conditionally
+      shell: bash
+      run: |
+        # Parse major and minor version from the input.
+        TFVERSION="${{ inputs.terraform_version }}"
+        MAJOR="$(echo "${TFVERSION}" | cut -d. -f1)"
+        MINOR="$(echo "${TFVERSION}" | cut -d. -f2)"
+
+        # Decide what to put into the Helm provider block
+        HELM_PROVIDER_VERSION=""
+        if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 13 ]; then
+          HELM_PROVIDER_VERSION='  version = "~> 0.10"'
+        fi
+
+        # Write one provider file, inserting our dynamic Helm version
+        cat <<EOF > provider.ci.tf
+        provider "aws" {
+          region = "eu-central-1"
+        }
+
+        provider "kubernetes" {}
+
+        provider "helm" {
+        ${HELM_PROVIDER_VERSION}
+        }
+        EOF
+
+        # Format the file
         terraform fmt -write=true provider.ci.tf
 
     - name: Terraform init


### PR DESCRIPTION
Fixs the helm provider version in case terraform provider is < 0.13. This prevents helm validate from failing