### PR TITLE
Fix misscopy on terraform format action

### DIFF
--- a/terraform-format/action.yml
+++ b/terraform-format/action.yml
@@ -6,7 +6,7 @@ inputs:
   terraform_version:
     description: 'Terraform version'
     required: true
-    default: '0.12.31'
+    default: 0.12.31
 
 runs:
   using: "composite"
@@ -14,60 +14,7 @@ runs:
     - name: Write provider file conditionally
       shell: bash
       run: |
-        # Parse major and minor version from the input.
-        TFVERSION="${{ inputs.terraform_version }}"
-        MAJOR="$(echo "${TFVERSION}" | cut -d. -f1)"
-        MINOR="$(echo "${TFVERSION}" | cut -d. -f2)"
-
-        # Decide what to put into the Helm provider block
-        HELM_PROVIDER_VERSION=""
-        if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 13 ]; then
-          HELM_PROVIDER_VERSION='  version = "~> 0.10"'
-        fi
-
-        # Write one provider file, inserting our dynamic Helm version
-        cat <<EOF > provider.ci.tf
-provider "aws" {
-  region = "eu-central-1"
-}
-
-provider "kubernetes" {}
-
-provider "helm" {
-${HELM_PROVIDER_VERSION}
-}
-EOF
-
-        # Format the file
-        terraform fmt -write=true provider.ci.tf
-
-    - name: Terraform init
-      shell: bash
-      run: terraform init
-
-    - name: Terraform validate
-      shell: bash
-      run: terraform validate
-
-    - name: Terraform fmt
-      shell: bash
-      run: terraform fmt -check -recursive -diff .
----
-name: Terraform Formatter
-description: Runs terraform validate and format
-
-inputs:
-  terraform_version:
-    description: 'Terraform version'
-    required: true
-    default: '0.12.31'
-
-runs:
-  using: "composite"
-  steps:
-    - name: Write provider file conditionally
-      shell: bash
-      run: |
+        mkdir -p $TF_PLUGIN_CACHE_DIR
         # Parse major and minor version from the input.
         TFVERSION="${{ inputs.terraform_version }}"
         MAJOR="$(echo "${TFVERSION}" | cut -d. -f1)"


### PR DESCRIPTION
This pull request includes significant changes to the `terraform-format/action.yml` file, primarily focusing on the removal of redundant steps and the addition of a new directory creation step.

Key changes:

* **Removal of redundant steps**:
  - Removed the entire block of steps that included writing a provider file conditionally, formatting the file, initializing Terraform, validating Terraform, and formatting Terraform recursively.

* **Addition of directory creation step**:
  - Added a step to create the directory specified by the `TF_PLUGIN_CACHE_DIR` environment variable.